### PR TITLE
Pass lists through verbatim, matching stdlib behavior

### DIFF
--- a/run/__init__.py
+++ b/run/__init__.py
@@ -50,6 +50,8 @@ import subprocess
 
 __version__ = "0.0.8"
 
+str_type = str if sys.version_info.major >= 3 else basestring
+
 
 class std_output(str):
 
@@ -118,7 +120,7 @@ class run(runmeta('base_run', (std_output, ), {})):
     @classmethod
     def create_process(cls, command, stdin, cwd, env, shell):
         return subprocess.Popen(
-            shlex.split(command),
+            shlex.split(command) if isinstance(command, str_type) else command,
             universal_newlines=True,
             shell=shell,
             cwd=cwd,
@@ -173,7 +175,10 @@ class run(runmeta('base_run', (std_output, ), {})):
         return std_output(self.process.communicate()[1])
 
     def __repr__(self):
-        return " | ".join([e.command for e in self.chain])
+        return " | ".join([
+            e.command if isinstance(e.command, str_type) else ' '.join(e.command)
+            for e in self.chain
+        ])
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ class PyTest(Command):
 setup(name='subprocess.run',
       version=run.__version__,
       data_files = [
-         (get_python_lib(), [pth_file]),
+         (get_python_lib(prefix=''), [pth_file]),
       ],
       packages=find_packages(),
       author='Sebastian Pawluś',


### PR DESCRIPTION
This actually also includes #4 because I forked from @brbsix's fork - can rebase if you'd like.

This resolves #5, though I can't prove it on Python 3 (which is really where one can prove behavior is 1:1 with stdlib, since this was added in 3.3) due to other issues relating to how `stdout` is parsed. Proven resolved on Python 2.7.