### PR TITLE
Pass lists through verbatim, matching stdlib behavior

### DIFF
--- a/run/__init__.py
+++ b/run/__init__.py
@@ -50,6 +50,8 @@ import subprocess
 
 __version__ = "0.0.8"
 
+str_type = str if sys.version_info.major >= 3 else basestring
+
 
 class std_output(str):
 
@@ -118,7 +120,7 @@ class run(runmeta('base_run', (std_output, ), {})):
     @classmethod
     def create_process(cls, command, stdin, cwd, env, shell):
         return subprocess.Popen(
-            shlex.split(command),
+            shlex.split(command) if isinstance(command, str_type) else command,
             universal_newlines=True,
             shell=shell,
             cwd=cwd,
@@ -173,7 +175,10 @@ class run(runmeta('base_run', (std_output, ), {})):
         return std_output(self.process.communicate()[1])
 
     def __repr__(self):
-        return " | ".join([e.command for e in self.chain])
+        return " | ".join([
+            e.command if isinstance(e.command, str_type) else ' '.join(e.command)
+            for e in self.chain
+        ])
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ class PyTest(Command):
 setup(name='subprocess.run',
       version=run.__version__,
       data_files = [
-         (get_python_lib(), [pth_file]),
+         (get_python_lib(prefix=''), [pth_file]),
       ],
       packages=find_packages(),
       author='Sebastian Pawluś',

--- a/tests.py
+++ b/tests.py
@@ -14,6 +14,7 @@ unix = pytest.mark.skipif(
 # dafault _commands
 class _commands:
     ls = 'ls -la'
+    ls_list = ['ls', '-la']
     rm = 'rm -r'
     more = 'more'
 
@@ -21,6 +22,7 @@ class _commands:
 if sys.platform.startswith('win'):
     class _commands:
         ls = 'dir'
+        ls_list = ['dir']
         rm = 'rmdir'
         more = 'more'
 
@@ -28,7 +30,7 @@ if sys.platform.startswith('win'):
 def test_run():
     to_run = [
         _commands.ls,
-        [_commands.ls],
+        _commands.ls_list,
     ]
 
     for cmd in to_run:

--- a/tests.py
+++ b/tests.py
@@ -26,14 +26,20 @@ if sys.platform.startswith('win'):
 
 
 def test_run():
-    output = run(_commands.ls)
+    to_run = [
+        _commands.ls,
+        [_commands.ls],
+    ]
 
-    assert output.lines
-    assert output
+    for cmd in to_run:
+        output = run(cmd)
 
-    assert isinstance(output.lines, list)
-    assert isinstance(output.qlines, list)
-    assert isinstance(output.qlines[0], list)
+        assert output.lines
+        assert output
+
+        assert isinstance(output.lines, list)
+        assert isinstance(output.qlines, list)
+        assert isinstance(output.qlines[0], list)
 
 
 def test_stdout():


### PR DESCRIPTION
This actually also includes #4 because I forked from @brbsix's fork - can rebase if you'd like.

This resolves #5, though I can't prove it on Python 3 (which is really where one can prove behavior is 1:1 with stdlib, since this was added in 3.3) due to other issues relating to how `stdout` is parsed. Proven resolved on Python 2.7.