### PR TITLE
Provide `returncode` and `check_returncode`

### DIFF
--- a/run/__init__.py
+++ b/run/__init__.py
@@ -159,10 +159,24 @@ class run(runmeta('base_run', (std_output, ), {})):
 
         return obj
 
+    def check_returncode(self):
+        if self.returncode != 0:
+            raise subprocess.CalledProcessError(
+                returncode=self.returncode,
+                cmd=self.command,
+            )
+
+    @property
+    def returncode(self):
+        return self.status
+
     @property
     def status(self):
-        self.process.communicate()
-        return self.process.returncode
+        if not hasattr(self, '_status'):
+            self.process.communicate()
+            self._status = self.process.returncode
+
+        return self._status
 
     @property
     def stdout(self):

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ class PyTest(Command):
 setup(name='subprocess.run',
       version=run.__version__,
       data_files = [
-         (get_python_lib(), [pth_file]),
+         (get_python_lib(prefix=''), [pth_file]),
       ],
       packages=find_packages(),
       author='Sebastian Pawluś',

--- a/tests.py
+++ b/tests.py
@@ -52,6 +52,24 @@ def test_status():
     assert run('%s not_existing_directory' % _commands.rm).status != 0
 
 
+def test_returncode():
+    assert run(_commands.ls).returncode == 0
+    # win workaround
+    assert run('%s not_existing_directory' % _commands.rm).returncode != 0
+
+
+def test_check_returncode():
+    assert run(_commands.ls).check_returncode() is None
+
+    # win workaround
+    try:
+        run('%s not_existing_directory' % _commands.rm).check_returncode()
+    except subprocess.CalledProcessError:
+        pass
+    else:
+        raise AssertionError('CalledProcessError was not raised')
+
+
 def test_chain():
     command = run('ps aux', 'wc -l', 'wc -c')
 


### PR DESCRIPTION
Just some more backports. Like #7, this also includes #4 from @brbsix. Open to a clean rebase, but the library is broken for my purposes without it so for now I left the commit in there.

https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess.returncode (this is basically what `status` was already doing here)
https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess.check_returncode