### PR TITLE
capture_output is not on by default in the standard library - replicate this behavior

### DIFF
--- a/run/__init__.py
+++ b/run/__init__.py
@@ -116,7 +116,16 @@ class run(runmeta('base_run', (std_output, ), {})):
     """
 
     @classmethod
-    def create_process(cls, command, stdin, cwd, env, shell):
+    def create_process(cls, command, stdin, cwd, env, shell, capture_output=False, **kwargs):
+        extra_args = kwargs.copy()
+
+        if capture_output:
+            if 'stdout' in kwargs or 'stderr' in kwargs:
+                raise ValueError('capture_output will override stdout/stderr kwargs')
+
+            extra_args['stdout'] = subprocess.PIPE
+            extra_args['stderr'] = subprocess.PIPE
+
         return subprocess.Popen(
             shlex.split(command),
             universal_newlines=True,
@@ -124,9 +133,8 @@ class run(runmeta('base_run', (std_output, ), {})):
             cwd=cwd,
             env=env,
             stdin=stdin,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             bufsize=0,
+            **extra_args
         )
 
     def __new__(cls, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ class PyTest(Command):
 setup(name='subprocess.run',
       version=run.__version__,
       data_files = [
-         (get_python_lib(), [pth_file]),
+         (get_python_lib(prefix=''), [pth_file]),
       ],
       packages=find_packages(),
       author='Sebastian Pawluś',


### PR DESCRIPTION
This can be seen even in a repl - stdlib `subprocess.run('clang')` will pass through the error about no input files, this library will swallow it because it sets stderr/stdout to `subprocess.PIPE` by default. This PR fixes that.

Same drill as my other two PRs, not 100% clean. Includes #4. Can rebase.